### PR TITLE
Add job posting parsing for more job boards

### DIFF
--- a/src/utils/parse-job-posting.util.ts
+++ b/src/utils/parse-job-posting.util.ts
@@ -24,6 +24,8 @@ export async function parseJobPosting() {
         ];
       case "www.glassdoor.ca":
         return ["JobDetails_jobDetailsContainer__sS1W1"];
+      case "www.careerbuilder.ca":
+        return ["data-display dn relative jdp-active"];
       default:
         return [];
     }


### PR DESCRIPTION
Job posting parsing has been added for more job boards:
- Monster
- Glassdoor
- CareerBuilder