### PR TITLE
Remove artificially generated contact information

### DIFF
--- a/src/utils/generate-cover-letter.util.ts
+++ b/src/utils/generate-cover-letter.util.ts
@@ -81,6 +81,8 @@ function formatCoverLetter(coverLetter: string, resume: string) {
   const patternsToRemove = [
     /\n(\[)?Phone Number(\])?/g,
     /\nPhone: /g,
+    /\n(\[)?Email(\])?/g,
+    /\nEmail: /g,
     ...insertPatternIfFake(resume, email),
     ...insertPatternIfFake(resume, number),
   ];


### PR DESCRIPTION
GPT will generate fake or stub contact information if it isn't provided in the resume. For example it will generate "[Phone Number]" or "123-456-7890" is no phone number is given. This has been fixed now.